### PR TITLE
Fix preprint type and upgrade to pydantic2 and fix breaking changes

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -21,4 +21,4 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: pytest .
       - run: shopt -s globstar && pyupgrade --keep-runtime-typing --py37-plus **/*.py
-      - run: safety check
+      - run: safety check --ignore 67599

--- a/openalexapi/__init__.py
+++ b/openalexapi/__init__.py
@@ -91,7 +91,7 @@ class OpenAlex(BaseModel):
         for i in range(0, len(ids), 50):
             url_ids = "|".join(ids[i : i + 50])
             url = self.base_url + f"works?filter=openalex_id:{url_ids}&per_page=50"
-            logger.debug(f"Fetching works {i} through {i+50}")
+            logger.debug(f"Fetching works {i} through {i + 50}")
             response = requests.get(url, headers=headers)
             if response.status_code == 200:
                 works += [Work(**w) for w in response.json()["results"]]

--- a/openalexapi/__init__.py
+++ b/openalexapi/__init__.py
@@ -21,8 +21,8 @@ class OpenAlex(BaseModel):
     :parameter=email
     """
 
-    email: Optional[EmailStr]
-    base_url = "https://api.openalex.org/"
+    email: Optional[EmailStr] = None
+    base_url: str = "https://api.openalex.org/"
 
     @backoff.on_exception(
         backoff.expo,

--- a/openalexapi/__init__.py
+++ b/openalexapi/__init__.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 import logging
 from typing import Optional, List
 

--- a/openalexapi/author.py
+++ b/openalexapi/author.py
@@ -8,8 +8,8 @@ from openalexapi.basetype import OpenAlexBaseType
 
 
 class Author(OpenAlexBaseType):
-    display_name: Optional[str]
-    orcid: Optional[str]
+    display_name: Optional[str] = None
+    orcid: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/openalexapi/author.py
+++ b/openalexapi/author.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from openalexapi.basetype import OpenAlexBaseType

--- a/openalexapi/authorship.py
+++ b/openalexapi/authorship.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional, List
 
 from pydantic import BaseModel

--- a/openalexapi/authorship.py
+++ b/openalexapi/authorship.py
@@ -12,8 +12,8 @@ from openalexapi.institution import Institution
 
 class Authorship(BaseModel):
     author_position: str
-    author: Optional[Author]
-    institutions: Optional[List[Institution]]
-    is_corresponding: Optional[bool]
-    raw_affiliation_string: Optional[str]
-    raw_affiliation_strings: Optional[List[str]]
+    author: Optional[Author] = None
+    institutions: Optional[List[Institution]] = None
+    is_corresponding: Optional[bool] = None
+    raw_affiliation_string: Optional[str] = None
+    raw_affiliation_strings: Optional[List[str]] = None

--- a/openalexapi/basetype.py
+++ b/openalexapi/basetype.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from pydantic import BaseModel

--- a/openalexapi/basetype.py
+++ b/openalexapi/basetype.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 
 class OpenAlexBaseType(BaseModel):
-    id: Optional[str]  # this is urls like https://openalex.org/W123
+    id: Optional[str] = None  # this is urls like https://openalex.org/W123
 
     @property
     def id_without_prefix(self):

--- a/openalexapi/biblio.py
+++ b/openalexapi/biblio.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 
 class Biblio(BaseModel):
-    volume: Optional[str]
-    issue: Optional[str]
-    first_page: Optional[str]
-    last_page: Optional[str]
+    volume: Optional[str] = None
+    issue: Optional[str] = None
+    first_page: Optional[str] = None
+    last_page: Optional[str] = None

--- a/openalexapi/biblio.py
+++ b/openalexapi/biblio.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from pydantic import BaseModel

--- a/openalexapi/concept.py
+++ b/openalexapi/concept.py
@@ -8,10 +8,10 @@ from openalexapi.basetype import OpenAlexBaseType
 
 
 class Concept(OpenAlexBaseType):
-    wikidata: Optional[str]
-    display_name: Optional[str]
-    level: Optional[int]
-    score: Optional[float]
+    wikidata: Optional[str] = None
+    display_name: Optional[str] = None
+    level: Optional[int] = None
+    score: Optional[float] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/openalexapi/concept.py
+++ b/openalexapi/concept.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from openalexapi.basetype import OpenAlexBaseType

--- a/openalexapi/enums.py
+++ b/openalexapi/enums.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from enum import Enum
 
 

--- a/openalexapi/enums.py
+++ b/openalexapi/enums.py
@@ -40,5 +40,7 @@ class WorkType(Enum):
     REFERENCE_ENTRY = "reference-entry"
     REPORT = "report"
     REPORT_SERIES = "report-series"
+    REVIEW = "review"
     STANDARD = "standard"
     STANDARD_SERIES = "standard-series"
+    SUPPLEMENTARY_MATERIALS = "supplementary-materials"

--- a/openalexapi/enums.py
+++ b/openalexapi/enums.py
@@ -31,6 +31,7 @@ class WorkType(Enum):
     PARATEXT = "paratext"
     PEER_REVIEW = "peer-review"
     POSTED_CONTENT = "posted-content"
+    PREPRINT = "preprint"
     PROCEEDINGS = "proceedings"
     PROCEEDINGS_ARTICLE = "proceedings-article"
     PROCEEDINGS_SERIES = "proceedings-series"

--- a/openalexapi/ids.py
+++ b/openalexapi/ids.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from pydantic import BaseModel

--- a/openalexapi/ids.py
+++ b/openalexapi/ids.py
@@ -8,9 +8,9 @@ from pydantic import BaseModel
 
 
 class Ids(BaseModel):
-    doi: Optional[str]
-    pmid: Optional[str]
-    mag: Optional[str]
+    doi: Optional[str] = None
+    pmid: Optional[str] = None
+    mag: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/openalexapi/institution.py
+++ b/openalexapi/institution.py
@@ -11,10 +11,10 @@ from openalexapi.basetype import OpenAlexBaseType
 
 
 class Institution(OpenAlexBaseType):
-    id: Optional[str]
-    display_name: Optional[str]
-    ror: Optional[str]
+    id: Optional[str] = None
+    display_name: Optional[str] = None
+    ror: Optional[str] = None
     country_code: Optional[
         Annotated[str, StringConstraints(max_length=2, min_length=2)]
-    ]
-    type: Optional[str]
+    ] = None
+    type: Optional[str] = None

--- a/openalexapi/institution.py
+++ b/openalexapi/institution.py
@@ -14,5 +14,7 @@ class Institution(OpenAlexBaseType):
     id: Optional[str]
     display_name: Optional[str]
     ror: Optional[str]
-    country_code: Optional[Annotated[str, StringConstraints(max_length=2, min_length=2)]]
+    country_code: Optional[
+        Annotated[str, StringConstraints(max_length=2, min_length=2)]
+    ]
     type: Optional[str]

--- a/openalexapi/institution.py
+++ b/openalexapi/institution.py
@@ -3,20 +3,16 @@ Copyright 2022 Dennis Priskorn
 """
 
 from typing import Optional
+from typing_extensions import Annotated
 
-from pydantic import ConstrainedStr
+from pydantic import StringConstraints
 
 from openalexapi.basetype import OpenAlexBaseType
-
-
-class CountryCode(ConstrainedStr):
-    max_length = 2
-    min_length = 2
 
 
 class Institution(OpenAlexBaseType):
     id: Optional[str]
     display_name: Optional[str]
     ror: Optional[str]
-    country_code: Optional[CountryCode]
+    country_code: Optional[Annotated[str, StringConstraints(max_length=2, min_length=2)]]
     type: Optional[str]

--- a/openalexapi/institution.py
+++ b/openalexapi/institution.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from pydantic import ConstrainedStr

--- a/openalexapi/mesh.py
+++ b/openalexapi/mesh.py
@@ -15,8 +15,8 @@ class Mesh(BaseModel):
 
     descriptor_ui: Optional[
         Annotated[str, StringConstraints(max_length=10, min_length=7)]
-    ]
+    ] = None
     is_major_topic: bool
     descriptor_name: str
-    qualifier_ui: Optional[str]
-    qualifier_name: Optional[str]
+    qualifier_ui: Optional[str] = None
+    qualifier_name: Optional[str] = None

--- a/openalexapi/mesh.py
+++ b/openalexapi/mesh.py
@@ -13,7 +13,9 @@ class Mesh(BaseModel):
     Unfortunately it does not contain the year when the term
     was added to MESH nor if it is still a valid MESH term"""
 
-    descriptor_ui: Optional[Annotated[str, StringConstraints(max_length=10, min_length=7)]]
+    descriptor_ui: Optional[
+        Annotated[str, StringConstraints(max_length=10, min_length=7)]
+    ]
     is_major_topic: bool
     descriptor_name: str
     qualifier_ui: Optional[str]

--- a/openalexapi/mesh.py
+++ b/openalexapi/mesh.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from pydantic import BaseModel, ConstrainedStr

--- a/openalexapi/mesh.py
+++ b/openalexapi/mesh.py
@@ -3,13 +3,9 @@ Copyright 2022 Dennis Priskorn
 """
 
 from typing import Optional
+from typing_extensions import Annotated
 
-from pydantic import BaseModel, ConstrainedStr
-
-
-class ConstrainedDescriptor(ConstrainedStr):
-    max_length = 10
-    min_length = 7
+from pydantic import BaseModel, StringConstraints
 
 
 class Mesh(BaseModel):
@@ -17,7 +13,7 @@ class Mesh(BaseModel):
     Unfortunately it does not contain the year when the term
     was added to MESH nor if it is still a valid MESH term"""
 
-    descriptor_ui: Optional[ConstrainedDescriptor]
+    descriptor_ui: Optional[Annotated[str, StringConstraints(max_length=10, min_length=7)]]
     is_major_topic: bool
     descriptor_name: str
     qualifier_ui: Optional[str]

--- a/openalexapi/openaccess.py
+++ b/openalexapi/openaccess.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from pydantic import BaseModel

--- a/openalexapi/openaccess.py
+++ b/openalexapi/openaccess.py
@@ -9,6 +9,6 @@ from pydantic import BaseModel
 
 class OpenAccess(BaseModel):
     is_oa: bool
-    oa_status: Optional[str]
-    oa_url: Optional[str]
-    any_repository_has_fulltext: Optional[bool]
+    oa_status: Optional[str] = None
+    oa_url: Optional[str] = None
+    any_repository_has_fulltext: Optional[bool] = None

--- a/openalexapi/venue.py
+++ b/openalexapi/venue.py
@@ -9,22 +9,22 @@ from openalexapi.basetype import OpenAlexBaseType
 
 
 class Source(OpenAlexBaseType):
-    display_name: Optional[str]
-    issn_l: Optional[str]  # What is this?
-    issn: Optional[List[str]]
-    host_organization: Optional[str]
-    host_organization_name: Optional[str]
-    host_organization_lineage: Optional[List[str]]
-    host_organization_lineage_names: Optional[List[str]]
-    type: Optional[str]
+    display_name: Optional[str] = None
+    issn_l: Optional[str] = None  # What is this?
+    issn: Optional[List[str]] = None
+    host_organization: Optional[str] = None
+    host_organization_name: Optional[str] = None
+    host_organization_lineage: Optional[List[str]] = None
+    host_organization_lineage_names: Optional[List[str]] = None
+    type: Optional[str] = None
 
 
 # This was host_venue but change to source
 class Venue(BaseModel):
-    is_oa: Optional[bool]
-    landing_page_url: Optional[str]  # Was url in the original metadata schema
-    pdf_url: Optional[str]  # This was later added
-    source: Optional[Source]
-    publisher: Optional[str]
-    license: Optional[str]
-    version: Optional[str]
+    is_oa: Optional[bool] = None
+    landing_page_url: Optional[str] = None  # Was url in the original metadata schema
+    pdf_url: Optional[str] = None  # This was later added
+    source: Optional[Source] = None
+    publisher: Optional[str] = None
+    license: Optional[str] = None
+    version: Optional[str] = None

--- a/openalexapi/venue.py
+++ b/openalexapi/venue.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional, List
 
 from pydantic import BaseModel

--- a/openalexapi/work.py
+++ b/openalexapi/work.py
@@ -38,8 +38,12 @@ class Work(OpenAlexBaseType):
     mesh: Optional[List[Mesh]] = []
     location_count: Optional[int] = None
     locations: Optional[List[Venue]] = None
-    referenced_works: Optional[List[str]] = None  # this is urls like https://openalex.org/W123
-    related_works: Optional[List[str]] = None  # this is urls like https://openalex.org/W123
+    referenced_works: Optional[List[str]] = (
+        None  # this is urls like https://openalex.org/W123
+    )
+    related_works: Optional[List[str]] = (
+        None  # this is urls like https://openalex.org/W123
+    )
     ngrams_url: Optional[str] = None
     abstract_inverted_index: Optional[Dict[str, List[int]]] = None
     cited_by_api_url: Optional[str] = None

--- a/openalexapi/work.py
+++ b/openalexapi/work.py
@@ -28,6 +28,7 @@ class Work(OpenAlexBaseType):
     language: Optional[str]
     primary_location: Optional[Venue]
     type: Optional[WorkType]
+    type_crossref: Optional[WorkType]
     open_access: Optional[OpenAccess]
     authorships: Optional[List[Authorship]]
     cited_by_count: Optional[int]

--- a/openalexapi/work.py
+++ b/openalexapi/work.py
@@ -18,31 +18,31 @@ from openalexapi.year import Year
 
 # Currently missing corresponding_author_ids, corresponding_institution_ids, apc_payment, best_oa_location, grants
 class Work(OpenAlexBaseType):
-    doi: Optional[str]
-    title: Optional[str]
-    display_name: Optional[str]
-    publication_year: Optional[int]
-    publication_date: Optional[str]
+    doi: Optional[str] = None
+    title: Optional[str] = None
+    display_name: Optional[str] = None
+    publication_year: Optional[int] = None
+    publication_date: Optional[str] = None
     ids: Ids
-    language: Optional[str]
-    primary_location: Optional[Venue]
-    type: Optional[WorkType]
-    type_crossref: Optional[WorkType]
-    open_access: Optional[OpenAccess]
-    authorships: Optional[List[Authorship]]
-    cited_by_count: Optional[int]
-    biblio: Optional[Biblio]
-    is_retracted: Optional[bool]
-    is_paratext: Optional[bool]
-    concepts: Optional[List[Concept]]
+    language: Optional[str] = None
+    primary_location: Optional[Venue] = None
+    type: Optional[WorkType] = None
+    type_crossref: Optional[WorkType] = None
+    open_access: Optional[OpenAccess] = None
+    authorships: Optional[List[Authorship]] = None
+    cited_by_count: Optional[int] = None
+    biblio: Optional[Biblio] = None
+    is_retracted: Optional[bool] = None
+    is_paratext: Optional[bool] = None
+    concepts: Optional[List[Concept]] = None
     mesh: Optional[List[Mesh]] = []
-    location_count: Optional[int]
-    locations: Optional[List[Venue]]
-    referenced_works: Optional[List[str]]  # this is urls like https://openalex.org/W123
-    related_works: Optional[List[str]]  # this is urls like https://openalex.org/W123
-    ngrams_url: Optional[str]
-    abstract_inverted_index: Optional[Dict[str, List[int]]]
-    cited_by_api_url: Optional[str]
-    counts_by_year: Optional[List[Year]]
-    updated_date: Optional[str]
-    created_date: Optional[str]
+    location_count: Optional[int] = None
+    locations: Optional[List[Venue]] = None
+    referenced_works: Optional[List[str]] = None  # this is urls like https://openalex.org/W123
+    related_works: Optional[List[str]] = None  # this is urls like https://openalex.org/W123
+    ngrams_url: Optional[str] = None
+    abstract_inverted_index: Optional[Dict[str, List[int]]] = None
+    cited_by_api_url: Optional[str] = None
+    counts_by_year: Optional[List[Year]] = None
+    updated_date: Optional[str] = None
+    created_date: Optional[str] = None

--- a/openalexapi/work.py
+++ b/openalexapi/work.py
@@ -4,8 +4,6 @@ Copyright 2022 Dennis Priskorn
 
 from typing import Optional, List, Dict
 
-from pydantic import conint
-
 from openalexapi.basetype import OpenAlexBaseType
 from openalexapi.authorship import Authorship
 from openalexapi.biblio import Biblio

--- a/openalexapi/work.py
+++ b/openalexapi/work.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional, List, Dict
 
 from pydantic import conint

--- a/openalexapi/year.py
+++ b/openalexapi/year.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 from typing import Optional
 
 from pydantic import BaseModel, ConstrainedInt

--- a/openalexapi/year.py
+++ b/openalexapi/year.py
@@ -9,5 +9,5 @@ from pydantic import BaseModel, Field
 
 
 class Year(BaseModel):
-    year: Optional[Annotated[int, Field(strict=True, ge=0)]]
+    year: Optional[Annotated[int, Field(strict=True, ge=0)]] = None
     cited_by_count: int

--- a/openalexapi/year.py
+++ b/openalexapi/year.py
@@ -3,14 +3,11 @@ Copyright 2022 Dennis Priskorn
 """
 
 from typing import Optional
+from typing_extensions import Annotated
 
-from pydantic import BaseModel, ConstrainedInt
-
-
-class ConstrainedYear(ConstrainedInt):
-    ge = 0
+from pydantic import BaseModel, Field
 
 
 class Year(BaseModel):
-    year: Optional[ConstrainedYear]
+    year: Optional[Annotated[int, Field(strict=True, ge=0)]]
     cited_by_count: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pydantic >= 2.0
 requests
 backoff~=1.11.1
-email-validator~=1.1.3
+email-validator >= 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic~=1.9.0
+pydantic >= 2.0
 requests
 backoff~=1.11.1
 email-validator~=1.1.3

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Dennis Priskorn
 """
+
 import unittest
 from unittest import TestCase
 


### PR DESCRIPTION
- Add preprint and type_crossref fields
- Minor black fixing
- Minor flake8 fix
- Add review and supplementary-materials
- Attempt to upgrade to pydantic > 2
- Use pydantic recommendation of Annotated in version 2
- Minor black formatting
- Fix base_url and force optional fields to None
- Minor black fix
- Update email-validator for pydantic support
- safety: Ignore known and intended issue with pip install
